### PR TITLE
iframe要素アクセシビリティの記述を修正

### DIFF
--- a/md_text/3-7.md
+++ b/md_text/3-7.md
@@ -67,11 +67,11 @@ HTML4では、`img`要素に`longdesc`属性が定義されていました。
 
 例外を除いて、`alt`属性は省略してはなりません。また、装飾的な画像の場合を除いて、画像と等価な代替テキストを属性値に記述しなければなりません。
 
-どのような場合に属性値を空にするのか(`alt=""`)、どのような代替テキストが望ましいか、属性そのものを省略するのはどのような場合かについての例は、HTML標準のRequirements for providing text to act as an alternative for images[^6]で詳しく説明されています。また、アクセシビリティの観点からAn alt Decision Tree[^7]というW3Cによるリソースも存在します。それぞれ参考にするとよいでしょう。
+どのような場合に属性値を空にするのか(`alt=""`)、どのような代替テキストが望ましいか、属性そのものを省略するのはどのような場合かについての例は、HTML標準のRequirements for providing text to act as an alternative for images[^4]で詳しく説明されています。また、アクセシビリティの観点からAn alt Decision Tree[^5]というW3Cによるリソースも存在します。それぞれ参考にするとよいでしょう。
 
-[^6]: https://html.spec.whatwg.org/multipage/images.html#alt
+[^4]: https://html.spec.whatwg.org/multipage/images.html#alt
 
-[^7]: https://www.w3.org/WAI/tutorials/images/decision-tree/
+[^5]: https://www.w3.org/WAI/tutorials/images/decision-tree/
 
 `alt`属性の値として何らかの代替テキストを置くことができる場合に、その書き方については絶対的な正解というものは存在しません。画像を通してウェブページで言いたいことは、そのページのコンテキストに依存します。どのような意図でその画像が埋め込まれるのか、制作の意図をしっかりと把握した上で、代替テキストを記述することが求められます。
 
@@ -116,13 +116,13 @@ HTML4では、`img`要素に`longdesc`属性が定義されていました。
 
 空でない`alt`属性が指定されている場合は`img`ロールとなり、意味のある画像が存在する扱いになります。多くのスクリーンリーダーは、代替テキストを読み上げたあとに「イメージ」「画像」などと読み上げ、そこに画像があることを伝えます。
 
-空の`alt`属性（すなわち`alt=""`）が指定されている場合は`presentation`ロールとなり、特定の役割を持たない状態になります。スクリーンリーダーは画像を無視し、何も読み上げません。画像の存在自体が伝えらないことに注意してください。装飾画像やスペーサー[^8]など、読まれない方が望ましいものに対して`alt=""`を指定するとよいでしょう。
+空の`alt`属性（すなわち`alt=""`）が指定されている場合は`presentation`ロールとなり、特定の役割を持たない状態になります。スクリーンリーダーは画像を無視し、何も読み上げません。画像の存在自体が伝えらないことに注意してください。装飾画像やスペーサー[^6]など、読まれない方が望ましいものに対して`alt=""`を指定するとよいでしょう。
 
-[^8]: “The img element must not be used as a layout tool.”と`img`要素はレイアウトツールとして使用してはならないことが仕様で示されています。 <https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element>
+[^6]: “The img element must not be used as a layout tool.”と`img`要素はレイアウトツールとして使用してはならないことが仕様で示されています。 <https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element>
 
-`alt`属性そのものが省略されている場合[^9]、意味のある画像が置かれていて、しかしながら代替テキストが提供されていないものと解釈されます。この場合、スクリーンリーダーは画像の内容を可能な限り伝えようとします。`title`属性やその他の属性で読めるテキストが指定されていればそれを読みますが、そうでない場合、多くのスクリーンリーダーは画像のファイル名を読もうとします。ファイル名が意味ある単語ならば役に立つこともありますが、システムが生成した無意味な英数字の羅列がファイル名に使われている場合、それがそのまま読まれることになります。
+`alt`属性そのものが省略されている場合[^7]、意味のある画像が置かれていて、しかしながら代替テキストが提供されていないものと解釈されます。この場合、スクリーンリーダーは画像の内容を可能な限り伝えようとします。`title`属性やその他の属性で読めるテキストが指定されていればそれを読みますが、そうでない場合、多くのスクリーンリーダーは画像のファイル名を読もうとします。ファイル名が意味ある単語ならば役に立つこともありますが、システムが生成した無意味な英数字の羅列がファイル名に使われている場合、それがそのまま読まれることになります。
 
-[^9]: `alt`を省略した場合は、追加の制約条件があります。<https://html.spec.whatwg.org/multipage/images.html#unknown-images>
+[^7]: `alt`を省略した場合は、追加の制約条件があります。<https://html.spec.whatwg.org/multipage/images.html#unknown-images>
 
 ```html
 <img src="/assets/93cc401e5a2939b25985d1db70de2aa9.jpg">
@@ -221,9 +221,9 @@ https://developer.mozilla.org/ja/docs/Web/HTML/Element/source
 
 `src`属性はリソースの存在するURLを指定します。上記の例では、YouTubeの埋め込みプレーヤーのURLを指定しています。
 
-`allow`属性はPermissions policy仕様[^10]に基づいて、許可する機能やAPIを指定するものです。`allowfullscreen`属性についてもPermissions policy仕様に基づくものであり、全画面表示のAPI `requestFullscreen()`を許可するブール型属性です。
+`allow`属性はPermissions policy仕様[^8]に基づいて、許可する機能やAPIを指定するものです。`allowfullscreen`属性についてもPermissions policy仕様に基づくものであり、全画面表示のAPI `requestFullscreen()`を許可するブール型属性です。
 
-[^10]: Permissions Policy <https://w3c.github.io/webappsec-permissions-policy/>
+[^8]: Permissions Policy <https://w3c.github.io/webappsec-permissions-policy/>
 
 また、`srcdoc`属性でHTMLを直接埋め込むことも可能です。
 
@@ -245,17 +245,19 @@ https://developer.mozilla.org/ja/docs/Web/HTML/Element/source
 <!-- /内容モデル -->
 
 <!-- a11y note -->
-`iframe`はアクセシビリティ上の問題を起こしやすい要素です。スクリーンリーダーでは`iframe`の内容をそのまま読む場合、能動的に操作をしないと中身を読まない場合など、種類や設定によって扱われ方が異なります。
+`iframe`はアクセシビリティ上の問題を起こしやすい要素です。スクリーンリーダーでは`iframe`の内容をそのまま読む場合や、能動的に操作をしないと中身を読まない場合など、種類や設定によって扱われ方が異なります。
 
-`iframe`要素に`title`属性をつけておくと、スクリーンリーダーはその内容を読んでくれることがあります。`iframe`を広告と考えて読み飛ばす利用者もいるため、有用な`iframe`には正確な名前をつけておくとよいでしょう。
+`iframe`要素に`title`属性を付けておくと、スクリーンリーダーはその`title`の値を読み上げることがあります。`iframe`を広告と考えて無条件に読み飛ばすユーザーもいるため、`iframe`には正確な名前を付けておくとよいでしょう。[^9]
+
+[^9]: WCAG2 SC 2.4.1 を満たすのに十分な方法です。Techniques for WCAG 2 H64も参照。 <https://www.w3.org/WAI/WCAG21/Techniques/html/H64>
 <!-- /a11y note -->
 
 <!-- security consideration -->
 `iframe`要素にはセキュリティ上の問題も多く知られており、使い方を誤ると攻撃に悪用されることがあります。また、`iframe`要素を悪用した攻撃もあります。その代表例が「クリックジャッキング」と呼ばれる手法で、この対策として多くのサイトが`iframe`で読み込まれないように制限を行っています。そのため、`iframe`要素で埋め込もうとしても、埋め込むことができない場合があります。
 
-また、`iframe`で読み込んだウェブページと、`iframe`の置かれたウェプページは、`postMessage`という機能で通信し、情報のやり取りをすることができます。本書では詳細を述べませんが、この利用法を誤ると、情報漏洩などのセキュリティ問題を起こすことがあります。[^11]
+また、`iframe`で読み込んだウェブページと、`iframe`の置かれたウェプページは、`postMessage`という機能で通信し、情報のやり取りをすることができます。本書では詳細を述べませんが、この利用法を誤ると、情報漏洩などのセキュリティ問題を起こすことがあります。[^10]
 
-[^11]: 徳丸浩著「体系的に学ぶ 安全なWebアプリケーションの作り方 第2版 脆弱性が生まれる原理と対策の実践」などが参考になります。
+[^10]: 徳丸浩著「体系的に学ぶ 安全なWebアプリケーションの作り方 第2版 脆弱性が生まれる原理と対策の実践」などが参考になります。
 <!--
 https://blog.jxck.io/entries/2018-03-08/feature-policy-permission-delegation.html
 -->
@@ -284,9 +286,9 @@ embed要素の内容モデルは"Nothing"です。空要素であり、終了タ
 
 子要素に`param`要素を持つことができます。これにより、`object`要素にパラメーターを与えることができます。
 
-次のコードはFlashプラグインを用いるFlashの動画を埋め込む古典的な例です。[^12]
+次のコードはFlashプラグインを用いるFlashの動画を埋め込む古典的な例です。[^11]
 
-[^12]: Flashプラグインのサポートは終了しているため、モダンな環境ではもはやこのコードは動作しません。
+[^11]: Flashプラグインのサポートは終了しているため、モダンな環境ではもはやこのコードは動作しません。
 
 ```html
 <!-- object要素のみで指定 -->


### PR DESCRIPTION
Close #146 

iframeのtitle属性でブロックスキップに言及してみました。

あわせて、脚注番号も調整しています。