### PR TITLE
3-7：iframe sandboxの修正

### DIFF
--- a/md_text/3-7.md
+++ b/md_text/3-7.md
@@ -265,7 +265,21 @@ https://developer.mozilla.org/ja/docs/Web/HTML/Element/source
 <!--
 https://blog.jxck.io/entries/2018-03-08/feature-policy-permission-delegation.html
 -->
-`iframe`要素に`sandbox`属性を指定すると、JavaScriptやフォームの実行等に対して制限を加えることができます。空文字列（`<iframe sandbox="">`）として使用することで、最大限の制限を行います。定められたトークンを（複数の場合はスペース区切りで）属性値に指定することで、個別の制限を許可します。トークンとその説明については、MDNを参照ください[^11]。
+`iframe`要素に`sandbox`属性を指定すると、iframeに埋め込まれたコンテンツの機能を制限できます。たとえば、JavaScriptの実行やフォームの送信などを禁止することが可能です。属性値が空文字列の場合（`sandbox=""` もしくは単に `sandbox` と指定した場合)、すべての機能を制限します。
+
+```html
+<iframe src="https://example.com/" sandbox></iframe>
+```
+
+特定機能の制限を解除したい場合は、その機能に対応するトークンを属性値に指定します。複数の機能を許可したい場合、スペース区切りで複数のトークンを指定することも可能です。たとえば、以下の例ではフォーム送信とダウンロードを許可しています。
+
+```html
+<iframe src="https://example.com/download-form"
+ sandbox="allow-forms allow-downloads"
+></iframe>
+```
+
+指定できるトークンの詳細はMDNを参照してください[^11]。
 
 [^11]: <https://developer.mozilla.org/ja/docs/Web/HTML/Element/iframe#attr-sandbox>
 


### PR DESCRIPTION
Partly #231

3-7

> 「空文字列として使用することで」これは iframe sandbox="" ということ？

- `<iframe sandbox="">`であることを明示
- `sandbox`に利用できるトークンについては脚注でMDNを参照するように