### PR TITLE
4-2：冗長なロールの説明追記

### DIFF
--- a/md_text/4-2.md
+++ b/md_text/4-2.md
@@ -262,7 +262,13 @@ ARIA in HTMLで許されている組み合わせであっても、不用意な�
 </main>
 ```
 
-これはエラーにはなりませんが、冗長です。ARIAの機能とまったく同一の機能がネイティブで利用できる場合は、ネイティブの機能だけを使用し、ARIAを使わないようにすることが推奨されています。
+これはエラーにはなりませんが、冗長です。かつてのHTML 5.0仕様では、`main`要素に`role="main"`をあわせて指定するようにアドバイスされていましたが、これは要素のネイティブロールを解釈できないレガシーユーザーエージェント向けのもので、モダンブラウザーに対してこのように指定する必要はありません。
+<!-- see also https://www.w3.org/TR/2018/SPSD-html5-20180327/grouping-content.html#the-main-element -->
+
+ARIAの機能とまったく同一の機能がネイティブで利用できる場合は、ネイティブの機能だけを使用し、ARIAを使わないようにすることがARIA in HTML仕様で推奨されています。
+<!-- https://www.w3.org/TR/html-aria/#rules-wd
+It is NOT RECOMMENDED for authors to set the ARIA role and aria-* attributes to values that match the implicit ARIA semantics defined in the table. Doing so is unnecessary and can potentially lead to unintended consequences.
+ -->
 
 ### 特殊な働きをするロール
 


### PR DESCRIPTION
Partly #239

> 「冗長なロール指定」PC-Talker向けとしてこの書き方を残そうという主張が過去にあったけど、そこについて言及する？

https://github.com/bakera/html-book/issues/239#issuecomment-940859959 に基づき追記。

IE11のことはレガシーユーザーエージェントとしておき、HTML 5.0にnoteでそんなことが書いてあったけど、ARIA in HTMLでは（規範的に）そうじゃないとなっている、というニュワンスを盛ってみました。