### PR TITLE
3-3：<div align>の説明を整理

### DIFF
--- a/md_text/3-3.md
+++ b/md_text/3-3.md
@@ -622,9 +622,7 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
 ```
 
 <!-- 互換性メモ -->
-### 廃止された属性: `align`属性
-
-かつてのHTMLでは、`div`要素に`align`属性が定義されていました。要素の内容の配置を指定するもので、主にテキストの左寄せ、右寄せ、センタリングを指定するために用いられてきました。現在ではCSSの`text-align`で代用可能です。文字寄せの指定はCSSで行います。
+かつてのHTMLでは、`div`要素に`align`属性が定義されていましたが、`p`要素の`align`属性と同様に廃止されています。詳しくは`p`要素の説明を参照してください。
 <!-- /互換性メモ -->
 
 <!-- 内容モデル -->


### PR DESCRIPTION
Close  #214

「廃止された属性: `align`属性」が同一Chapterに2回出てくるのを回避するために修正。
div要素のalign属性は、p要素のものと同一の振る舞いでもあるため、p要素に寄せてみました。