### PR TITLE
Chapter2-4のレビュー反映

### DIFF
--- a/md_text/2-4.md
+++ b/md_text/2-4.md
@@ -24,7 +24,7 @@
 
 仕様では、各要素の説明に"Content Model"という項目があり、内容モデルが書かれています。たとえば、`ol`要素の内容モデルは以下のようになっています。
 
->Content Model:
+>Content Model:  
 >Zero or more li and script-supporting elements.
 
 これを読むと、1つ以上の`li`要素を含む必要があることがわかります。なお、"script-supporting elements" とは`script`要素と`template`要素を指し、これらはほぼどこにでも書くことができます。
@@ -50,7 +50,6 @@
 > Phrasing content.
 
 "Phrasing content" は要素の「カテゴリ」(categories) の1つです。カテゴリは、似た性質を持つ要素をいくつかのグループに分類したものであり、要素自身がどの内容モデルに属しているのかを決めるものです。
-要素自身が特定のカテゴリに属していることと、特定のカテゴリの内容モデルを持つことの違いに注意してください。
 
 `p`要素と`mark`要素のカテゴリはそれぞれ以下のようになっています。
 
@@ -65,7 +64,9 @@
 > Phrasing content.  
 > Palpable content.
 
-先に挙げた例では、`p`に`mark`を入れることはできますが、その逆はできないと紹介しました。内容モデルを見ると、`p`要素も`mark`要素も内容モデルは"Phrasing content"です。その一方でカテゴリを見ると、`mark`にはカテゴリに"Phrasing content"と記載されていますので、`p`は`mark`を子にすることができます。しかし、`p`要素のカテゴリには"Phrasing content"がありませんから、`mark`は`p`を子にすることができません。要素自身が特定のカテゴリーにあることと、
+先に挙げた例では、`p`に`mark`を入れることはできますが、その逆はできないと紹介しました。ここで、要素自身が特定のカテゴリーに所属することと、要素が特定のカテゴリーの内容モデルを持つこととの違いに注意にしてください。`p`要素は自身がFlow contentおよびPalpable contentのカテゴリーである一方で、Phrasing contentの内容モデルを持っています。`mark`要素はFlow content、Phrasing contentおよびPalpable contentのカテゴリーであり、Phrasing contentの内容モデルを持っています。
+
+`p`要素も`mark`要素も内容モデルはPhrasing contentです。`mark`要素はカテゴリーとして"Phrasing content"であるので、`mark`要素は`p`要素の子になることができます。その一方で、`p`要素はカテゴリーとして"Phrasing content"ではないので、`p`要素は`mark`要素の子になることができません。
 
 ### 要素のカテゴリ
 

--- a/md_text/2-4.md
+++ b/md_text/2-4.md
@@ -54,16 +54,18 @@
 
 `p`要素と`mark`要素のカテゴリはそれぞれ以下のようになっています。
 
+`p`要素
 > Categories:  
 > Flow content.  
 > Palpable content.
 
+`mark`要素
 > Categories:  
 > Flow content.  
 > Phrasing content.  
 > Palpable content.
 
-先に挙げた例では、`p`に`mark`を入れることはできますが、その逆はできないと紹介しました。内容モデルを見ると、`p`要素も`mark`要素も内容モデルは"Phrasing content"です。その一方でカテゴリを見ると、`mark`にはカテゴリに"Phrasing content"と記載されていますので、`p`は`mark`を子にすることができます。しかし、`p`要素のカテゴリには"Phrasing content"がありませんから、`mark`は`p`を子にすることができません。
+先に挙げた例では、`p`に`mark`を入れることはできますが、その逆はできないと紹介しました。内容モデルを見ると、`p`要素も`mark`要素も内容モデルは"Phrasing content"です。その一方でカテゴリを見ると、`mark`にはカテゴリに"Phrasing content"と記載されていますので、`p`は`mark`を子にすることができます。しかし、`p`要素のカテゴリには"Phrasing content"がありませんから、`mark`は`p`を子にすることができません。要素自身が特定のカテゴリーにあることと、
 
 ### 要素のカテゴリ
 


### PR DESCRIPTION
Partly #228

> - 「p要素とmark要素のカテゴリはそれぞれ以下のようになっています。」どっちの引用がどっちのことか明示したほうがよさそう
> - Content modelとCategoriesと入れ子の関係の説明がパッとわからなかった（もともと知ってたので脳内補完した感じ）。ここは頻出質問と思うので丁寧目がよさそう。以下みたいな表とか図があったほうが良い？
```
p
Categories：自分の属するカテゴリ：何に含まれることができるか ≒ 親：Flow content. Palpable content. 
Content model：自分が何を内容にできるか ≒ 子：**Phrasing content**.

mark
Categories：自分の属するカテゴリ：何に含まれることができるか ≒ 親：Flow content. **Phrasing content**. Palpable content.
Content model：自分が何を内容にできるか ≒ 子：**Phrasing content**.
```

ということで、カテゴリーの引用部分で`p`要素と`mark`要素を明記しつつ、（図こそ加えてませんがひとまず）カテゴリーと内容モデルの説明に手を加えてみました。