### PR TITLE
3-2：section要素のコード例を拡充

### DIFF
--- a/md_text/3-2.md
+++ b/md_text/3-2.md
@@ -439,25 +439,29 @@ HTMLには「見出し」(heading) を表現する要素が用意されていま
 <!-- よくない例 -->
 ```html
 <section>
+  <h2>セクションについて</h2>
   <section>
-    <section>
-      <h3><code>section</code>要素</h3>
-      <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
-    </section>
+    <p>セクション（section）は、一般には区分や区画といった意味を持ちます。</p>
+  </section>
+  <section>
+    <h3><code>section</code>要素</h3>
+    <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
   </section>
 </section>
 ```
 
 <!-- 修正例 -->
 ```html
-<div>
-  <div>
-    <section>
-      <h3><code>section</code>要素</h3>
-      <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
-    </section>
+<section>
+  <h2>セクションについて</h2>
+  <div><!-- 見た目の囲み -->
+    <p>セクション（section）は、一般には区分や区画といった意味を持ちます。</p>
   </div>
-</div>
+  <section>
+    <h3><code>section</code>要素</h3>
+    <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
+  </section>
+</section>
 ```
 
 <!-- a11y note -->

--- a/md_text/3-2.md
+++ b/md_text/3-2.md
@@ -436,12 +436,28 @@ HTMLには「見出し」(heading) を表現する要素が用意されていま
 
 この要素は汎用のコンテナ要素ではないことに注意してください。すでに説明したように、タイトルのないセクションができることは望ましくありません。見出しを持たないようなブロック、たとえば見た目上の単なる囲みや、JavaScriptで制御するためのエリア等が必要な場合は、`div`要素を使用します。
 
-<!--例示は必要？-->
+<!-- よくない例 -->
 ```html
 <section>
-  <h3><code>section</code>要素</h3>
-  <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
+  <section>
+    <section>
+      <h3><code>section</code>要素</h3>
+      <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
+    </section>
+  </section>
 </section>
+```
+
+<!-- 修正例 -->
+```html
+<div>
+  <div>
+    <section>
+      <h3><code>section</code>要素</h3>
+      <p><code>section</code>要素は、文書またはアプリケーションの一般的なセクションを表します。
+    </section>
+  </div>
+</div>
 ```
 
 <!-- a11y note -->


### PR DESCRIPTION
Partly #231

> section要素、divの代わりに使われがち問題は例を挙げたほうがいいかも（section > seciton > sectionみたいなやつ）

とりあえず例示を加えてみましたがもう少し調整が必要？

コード例は`class`を付け加えた方がいいのか、地の文はもう少し説明加えた方がいいのか