### PR TITLE
3-5：prerenderの記載を入れ替えて少し追記

### DIFF
--- a/md_text/3-5.md
+++ b/md_text/3-5.md
@@ -508,16 +508,6 @@ If preconnect URL's scheme is not one of "http" or "https" then abort these step
 <link rel="prefetch" href="next.js">
 ```
 
-### リンクタイプ`prerender`
-
-`link`要素でリンクタイプ`prerender`を指定すると、リソースをバックグラウンドでレンダリングしておくことが期待できます。
-
-ユーザーが次に遷移するページが明確な場合などに、次ページのレンダリング処理をあらかじめ行っておくことで、表示の高速化が期待できます。
-
-```html
-<link rel="prerender" href="https://example.com/next-page.html">
-```
-
 ### リンクタイプ`preload`
 
 `link`要素でリンクタイプ`preload`を指定すると、リソースを事前にダウンロードし、ブラウザーにキャッシュさせることが期待できます。
@@ -557,6 +547,16 @@ div.hoge {background-image: url: ("bgimage.png");
 ```
 
 `as`属性、`integrity`属性については、リンクタイプ`preload`と同様です。リンクタイプ`preload`を参照してください。
+
+### リンクタイプ`prerender`
+
+`link`要素でリンクタイプ`prerender`を指定すると、リソースを事前にダウンロードした上で、バックグラウンドでレンダリングしておくことが期待できます。
+
+ユーザーが次に遷移するページが明確な場合などに、次ページのレンダリング処理をあらかじめ行っておくことで、表示の高速化が期待できます。
+
+```html
+<link rel="prerender" href="https://example.com/next-page.html">
+```
 
 ### リンクタイプ`stylesheet`
 


### PR DESCRIPTION
Close  #301

prerenderがpreloadよりも強力であることがクリアではないのがわかりにくい原因と考え、以下を行いました。

- prerenderをpreloadよりも後の場所に移動（pre系APIで強力なものほど後ろになるように並び替え）
- 「リソースを事前にダウンロードした上で、」を挿入
