### PR TITLE
maxlengthの微調整

### DIFF
--- a/md_text/3-9.md
+++ b/md_text/3-9.md
@@ -528,7 +528,7 @@ https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#limiting
 >User agents may prevent the user from causing the element's API value to be set to a value whose length is greater than the element's maximum allowed value length.
 -->
 
-このため、パスワード入力欄に`maxlength`を指定する場合は注意が必要です。入力している文字が見えないため、ユーザーは入力できていないことに気づかないことがあります。
+このため、入力欄に`maxlength`を指定する場合は注意が必要です。特にパスワードの入力欄は入力している文字が見えないため、ユーザーは入力できていないことに気づかないことがあります。
 
 ### `size`属性
 
@@ -542,8 +542,7 @@ https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#limiting
 
 厳密に文字数の幅にはないことに注意してください。この値はブラウザーによって解釈が異なることが知られており、CSSの`width`プロパティで`em`や`ex`で指定した幅とも異なります。<!-- MDNにはemっぽいことが書いてあるが実際試してみると明らかに異なる幅になる。 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefsize -->なお、スタイルシートで幅が指定される場合には`size`属性の指定よりも優先されます。正確な大きさを指定したい場合はスタイルシートで指定するとよいでしょう。
 
-この幅は実際に入力できる文字数とは関係ないことに注意してください。
-入力文字数の制限は`maxlength`属性や`minlength`属性で行います。
+この幅は実際に入力できる文字数とは関係ないことに注意してください。入力文字数の制限は`maxlength`属性や`minlength`属性で行います。
 
 ### `readonly`属性
 


### PR DESCRIPTION
Close #349

> 「このため、パスワード入力欄にmaxlengthを指定する場合は注意が必要です。」パスワードに限らず、入力欄の幅を超えているmaxlengthだと切り捨てに気づかない問題があるかも？

少し文言を調整しただけですが。