### PR TITLE
dl要素の注意点を追記

### DIFF
--- a/md_text/3-3.md
+++ b/md_text/3-3.md
@@ -480,9 +480,9 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
 
 ### アクセシビリティ上の注意点
 
-`dl`要素のアクセシビリティ上の扱いには注意が必要です。2021年12月現在のARIA in HTMLによる定義では、`dl`要素にはデフォルトのARIAロールはなく、`dt`、`dd`要素のロールはそれぞれ`term`、`definition`となります。しかし、WAI-ARIA 1.0では、`dl`要素は`list`ロール、`dt`と`dd`要素は`listitem`ロールとされていました。
+`dl`要素のアクセシビリティ上の扱いには注意が必要です。2021年12月現在のARIA in HTMLによる定義では、`dl`要素にはデフォルトのARIAロールはなく、`dt`、`dd`要素のロールはそれぞれ`term`、`definition`となります。
 
-そのため、スクリーンリーダーによっては、`dl`要素を単なるリストとし、`dt`と`dd`要素をいずれもリスト項目として等しく扱うことがあります。たとえば、以下の例は名前・値の組み合わせが1つですが、「2件のリスト」と読み上げられる場合があります。
+しかし、2018年6月時点のARIA in HTMLでは、`dl`要素は`list`ロール、`dt`と`dd`要素は`listitem`ロールとされていました<!-- このコミットで修正されている: https://github.com/w3c/html-aria/commit/bdc9341a86a4b7e22db86e38888c530517f09b73 -->。そのため、スクリーンリーダーによっては、`dl`要素を単なるリストとし、`dt`と`dd`要素をいずれもリスト項目として等しく扱うことがあります。たとえば、以下の例は名前・値の組み合わせが1つですが、「2件のリスト」と読み上げられる場合があります。
 
 ```html
 <dl>
@@ -491,12 +491,14 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
 </dl>
 ```
 
-さらに事態をややこしくすることに、2021年12月現在のWAI-ARIA 1.2では、`term`ロールは`dfn`要素に対応するものとされ、`definition`ロールは`dd`要素と無関係なロールと位置付けられています。そして、Editor's DraftのWAI-ARIA 1.3によれば、`associationlist`、`associationlistitemkey`、`associationlistitemvalue`というロールが新たに定義され、`dl`、`dt`、`dd`要素に対応付けられるとされています。このように、WAI-ARIA仕様も迷走しており、当面の間、スクリーンリーダーでは`dl`関連要素がHTML仕様のとおりに解釈されないと考えられます。
+なお、2021年12月現在で勧告候補となっているWAI-ARIA 1.2では、`term`ロールは`dfn`要素に対応するものとされ、`definition`ロールは`dd`要素と無関係なものと位置付けられています。
 
+また、2021年12月現在でEditor's DraftとなっているWAI-ARIA 1.3では、`dl`、`dt`、`dd`要素に対応する`associationlist`、`associationlistitemkey`、`associationlistitemvalue`というロールが新たに定義されています。
+
+このように、`dl`要素に関連するロールの仕様はかなり流動的です。当面の間、スクリーンリーダーによる`dl`関連要素の扱いは安定しないものと考えられます。
 <!--
 https://www.w3.org/TR/2021/CR-wai-aria-1.2-20210302/#definition
 https://www.w3.org/TR/2021/CR-wai-aria-1.2-20210302/#term
-
 https://w3c.github.io/aria/#associationlist
 -->
 

--- a/md_text/3-3.md
+++ b/md_text/3-3.md
@@ -420,7 +420,7 @@ ARIA in HTML仕様では、`blockquote`要素にデフォルトのARIAロール�
 
 `dl`要素は、名前と値のグループから構成される、説明リスト（description list）あるいは関連リスト (association list) を表します。古いHTMLでは用語の定義のために用いられており、定義リスト（definition list）と呼ばれていました。現在は意味が再定義され、用語定義以外の用途にも使えるようになっています。名前と値のグループの例としては、用語とその定義、メタデータのトピックと値、質問と回答などが挙げられます。
 
-<!--内容モデル -->
+### 内容モデル
 `dl`要素の内容モデルは以下のように定義されています。
 
 Either: Zero or more groups each consisting of one or more dt elements followed by one or more dd elements, optionally intermixed with script-supporting elements. Or: One or more div elements, optionally intermixed with script-supporting elements.
@@ -479,9 +479,10 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
 ```
 
 ### アクセシビリティ上の注意点
-`dl`要素のアクセシビリティ上の扱いには注意が必要です。現在の定義では、`dl`にはデフォルトのARIAロールはなく、`dt`、`dd`のロールはそれぞれ`term`、`definition`となります。
 
-ところで、かつては`dl`のロールが`list`、`dt`と`dd`はいずれも`listitem`とされていた時期があります。このため、スクリーンリーダーの中には`dl`を`ul`として、`dt`と`dd`を`li`として扱う場合があります。たとえば、以下の例は名前・値の組み合わせが1つしかありませんが、「2件のリスト」と読み上げられる場合があります。
+`dl`要素のアクセシビリティ上の扱いには注意が必要です。現在の定義では、`dl`にはデフォルトのARIAロールはなく、`dt`、`dd`のロールはそれぞれ`term`、`definition`となります。しかし、WAI-ARIA 1.0では、`dl`は`list`ロール、`dt`と`dd`は`listitem`ロールとされていました。
+
+そのため、スクリーンリーダーによっては、`dl`を単なるリストとし、`dt`と`dd`をいずれもリスト項目として等しく扱うことがあります。たとえば、以下の例は名前・値の組み合わせが1つですが、「2件のリスト」と読み上げられる場合があります。
 
 ```html
 <dl>
@@ -489,6 +490,19 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
   <dd>value</dd>
 </dl>
 ```
+
+`dl`要素は一見便利に利用できますが、本当に`dl`要素が適切かどうかは慎重に検討してください。
+
+`dt`要素は見出しではないため、小見出しのようなものを`dt`要素とすると、見出しにジャンプする機能は提供されません。`dd`要素の内容が長文になるようなケースでは、見出しを利用したほうがよいでしょう。
+
+対談や会話の表現に`dl`要素を利用し、話者を`dt`要素、発言を`dd`要素で表現するケースも見られますが、HTML Standardでは単純に`p`要素で表現することを勧めています[^5]。
+
+[^5]: <https://html.spec.whatwg.org/multipage/semantics-other.html#conversations>
+<!--
+>Instead, authors are encouraged to mark up conversations using p elements and punctuation. 
+-->
+
+ただし、発言に対する返答が階層構造になるような複雑なケースについては、`dl`要素で表現するケースも例示されています。対応関係や階層構造を表現する必要がある場合は`dl`要素を利用し、そうでない場合は他の要素を検討すると良いでしょう。
 <!-- /a11y note -->
 
 ## `figure`要素

--- a/md_text/3-3.md
+++ b/md_text/3-3.md
@@ -480,9 +480,9 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
 
 ### アクセシビリティ上の注意点
 
-`dl`要素のアクセシビリティ上の扱いには注意が必要です。現在の定義では、`dl`にはデフォルトのARIAロールはなく、`dt`、`dd`のロールはそれぞれ`term`、`definition`となります。しかし、WAI-ARIA 1.0では、`dl`は`list`ロール、`dt`と`dd`は`listitem`ロールとされていました。
+`dl`要素のアクセシビリティ上の扱いには注意が必要です。2021年12月現在のARIA in HTMLによる定義では、`dl`要素にはデフォルトのARIAロールはなく、`dt`、`dd`要素のロールはそれぞれ`term`、`definition`となります。しかし、WAI-ARIA 1.0では、`dl`要素は`list`ロール、`dt`と`dd`要素は`listitem`ロールとされていました。
 
-そのため、スクリーンリーダーによっては、`dl`を単なるリストとし、`dt`と`dd`をいずれもリスト項目として等しく扱うことがあります。たとえば、以下の例は名前・値の組み合わせが1つですが、「2件のリスト」と読み上げられる場合があります。
+そのため、スクリーンリーダーによっては、`dl`要素を単なるリストとし、`dt`と`dd`要素をいずれもリスト項目として等しく扱うことがあります。たとえば、以下の例は名前・値の組み合わせが1つですが、「2件のリスト」と読み上げられる場合があります。
 
 ```html
 <dl>
@@ -490,6 +490,15 @@ Either: Zero or more groups each consisting of one or more dt elements followed 
   <dd>value</dd>
 </dl>
 ```
+
+さらに事態をややこしくすることに、2021年12月現在のWAI-ARIA 1.2では、`term`ロールは`dfn`要素に対応するものとされ、`definition`ロールは`dd`要素と無関係なロールと位置付けられています。そして、Editor's DraftのWAI-ARIA 1.3によれば、`associationlist`、`associationlistitemkey`、`associationlistitemvalue`というロールが新たに定義され、`dl`、`dt`、`dd`要素に対応付けられるとされています。このように、WAI-ARIA仕様も迷走しており、当面の間、スクリーンリーダーでは`dl`関連要素がHTML仕様のとおりに解釈されないと考えられます。
+
+<!--
+https://www.w3.org/TR/2021/CR-wai-aria-1.2-20210302/#definition
+https://www.w3.org/TR/2021/CR-wai-aria-1.2-20210302/#term
+
+https://w3c.github.io/aria/#associationlist
+-->
 
 `dl`要素は一見便利に利用できますが、本当に`dl`要素が適切かどうかは慎重に検討してください。
 


### PR DESCRIPTION
fix #342 
dl要素について、見出しではないこと、会話は`p`が勧められていることを追記しました。
ついでに a11y の冒頭の文章も少し調整しています。