### PR TITLE
3-9にnovalidate属性を追加

### DIFF
--- a/md_text/3-9.md
+++ b/md_text/3-9.md
@@ -39,6 +39,18 @@ HTMLには、フォームやフォームコントロール表現する要素が�
 <!-- /内容モデル -->
 
 ### 属性
+<!--
+accept-charset — 説明あり
+action — 説明あり
+autocomplete — 共通のところに追記
+enctype — 説明あり
+method — 説明あり
+name — 共通のところを参照?
+novalidate — 説明を追加
+target — 説明あり
+rel - 説明あり
+-->
+`form`要素にはフォーム送信の制御に関する属性がいくつかあります。また、下記の他に`autocomplete`属性を指定できます。`autocomplete`属性については、後述のフォームコントロールの共通属性を参照してください。
 
 #### `method`属性
 
@@ -159,6 +171,20 @@ name2=value2
 `form`要素にも`target`属性と`rel`属性を指定できます。これらは`a`要素の同名の属性と同じものです。Chapter3-5を参照してください。
 
 `rel`属性には基本的に`a`要素と同じリンクタイプを指定できますが、`form`要素の場合にはリンクタイプ`alternate`、`author`、`bookmark`、`tag`を利用できません。
+
+#### `novalidate`属性
+
+`novalidate`属性を指定すると、フォーム送信時の入力値の検証が無効になります。`novalidate`属性はブール型属性です。
+
+特定の形式の値のみを許すフォームコントロール (`type=email`など) や、`required`属性、`pattern`属性、などで値が制限されている場合、「クライアント側フォーム検証」(Client-side form validation)[^99]が行われ、条件を満たしていないとエラーとなります。
+
+[^99]: https://html.spec.whatwg.org/multipage/forms.html#client-side-form-validation
+
+`novalidate`属性を指定すると、この検証を無効にし、無条件でフォーム送信ができるようになります。
+
+#### `name`属性
+
+`form`要素に`name`属性を指定すると、フォームに名前をつけられます。この名前は、JavaScriptから参照する際に利用できます。フォームコントロールの`name`属性と異なり、フォーム送信時にこの名前がデータとして送信されることはありません。
 
 #### `accept-charset`属性
 
@@ -897,7 +923,6 @@ https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#limiting
 `placeholder`属性にはさまざまなデメリットがあり、扱いが難しいものです。`placeholder`属性を用いる場合には、これらに注意するようにしましょう。
 
 ## フォームコントロールの共通属性
-
 <!--
 4.10.18.1 Naming form controls: the name attribute
 4.10.18.2 Submitting element directionality: the dirname attribute
@@ -992,6 +1017,8 @@ animal%5B%5D=cat&animal%5B%5D=dog
 
 `autocomplete`属性を指定すると、ユーザーエージェントに対して、フォームコントロールの入力補完に関するヒントを与えることができます。この属性は大きく分けて2種類あり、ひとつは自動補完の動作自体を制御するもの（autofill expectation mantle）、もうひとつは値の種類を指定するもの（autofill anchor mantle）です。
 <!-- 表現至難。mantleは外套、マントのmantleでは原文はwear...mantleと「マントを羽織る」という表現。 -->
+
+この属性は`form`要素にも指定でき、その場合はフォーム内のコントロールのデフォルトの挙動を指定します。個々のフォームコントロールに`autocomplete`属性が指定されている場合、そちらが優先されます。
 
 #### 自動補完の動作を制御する
 

--- a/md_text/3-9.md
+++ b/md_text/3-9.md
@@ -176,7 +176,7 @@ name2=value2
 
 `novalidate`属性を指定すると、フォーム送信時の入力値の検証が無効になります。`novalidate`属性はブール型属性です。
 
-特定の形式の値のみを許すフォームコントロール (`type=email`など) や、`required`属性、`pattern`属性、などで値が制限されている場合、「クライアント側フォーム検証」(Client-side form validation)[^99]が行われ、条件を満たしていないとエラーとなります。
+特定の形式の値のみを許すフォームコントロール (`type=email`など) や、`required`属性、`pattern`属性などで値が制限されている場合、「クライアント側フォーム検証」(Client-side form validation)[^99]が行われ、条件を満たしていないとエラーとなります。
 
 [^99]: https://html.spec.whatwg.org/multipage/forms.html#client-side-form-validation
 


### PR DESCRIPTION
novalidate属性が抜けていて、かつformvalidateの説明のために必要なので追加しました。
また、formの属性の見出し直下に文を追加、autocompleteにform要素の記述を追加しています。
ついでにname属性も追加しました。