### PR TITLE
改行の正規化の話を追加してみる

### DIFF
--- a/text/chapter2/2_2.txt
+++ b/text/chapter2/2_2.txt
@@ -63,6 +63,9 @@ Chapter2-1で説明したように、HTMLではタグを使って要素の種類
 ASCII空白文字はInfra Standardで定義されており、U+0009（タブ）、U+000A（LF）、U+000C（FF）、U+000D（CR）、U+0020（ASCIIスペース）が含まれます。
 https://infra.spec.whatwg.org/#ascii-whitespace
 
+なお、HTML構文の場合、構文解析の前に「改行の正規化（normalize newlines）」が行われることになっているため、CRやCR+LFはLFに置き換えられてからパースされます。
+https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
+
 〓06〓複数の属性を改行で区切った例
 ＜コード＞
 <a

--- a/text/chapter2/2_2.txt
+++ b/text/chapter2/2_2.txt
@@ -63,7 +63,7 @@ Chapter2-1で説明したように、HTMLではタグを使って要素の種類
 ASCII空白文字はInfra Standardで定義されており、U+0009（タブ）、U+000A（LF）、U+000C（FF）、U+000D（CR）、U+0020（ASCIIスペース）が含まれます。
 https://infra.spec.whatwg.org/#ascii-whitespace
 
-なお、HTML構文の場合、構文解析の前に「改行の正規化（normalize newlines）」が行われることになっているため、CRやCR+LFはLFに置き換えられてからパースされます。
+なお、HTML構文の場合、構文解析前の「改行の正規化（normalize newlines）」により、CRやCR+LFはLFに置き換えられてからパースされます。
 https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
 
 〓06〓複数の属性を改行で区切った例


### PR DESCRIPTION
HTML構文のパース時にCRやCR+LFがLFに置き換えられることを書き忘れていた話。

現状で最も近い話をしているのは P059 にあるASCII空白文字に関するnoteだと思うので、そこに追加する形で入れてみました。
noteの下には余白があるので入るはずです。