### PR TITLE
fix #708 注釈の中の空行を削除

### DIFF
--- a/epub_text/2-4.md
+++ b/epub_text/2-4.md
@@ -152,7 +152,6 @@ document.querySelector('ul').childNodes[0].length;
 0個以上の`li`要素、もしくは*「script-supporting elements」*を子要素にしなければならないことがわかります[^7]。この定義では0個以上なので、内容モデルの観点からは内容を空にもできます。
 
 [^7]: script-supporting elementsは`script`要素と`template`要素を指すもので、ほぼどこにでも書くことができます。  
-  
 3.2.5.2.9 Script-supporting elements  
 <https://html.spec.whatwg.org/multipage/dom.html#scriptsupporting-elements>
 


### PR DESCRIPTION
fix #708
注釈内に空白行があるとpandocの処理がどうもうまくいかないようなので、空白行を削除しました。